### PR TITLE
Collapses bottom bar when clicked

### DIFF
--- a/ui/tmnt/static/tmnt.css
+++ b/ui/tmnt/static/tmnt.css
@@ -141,6 +141,13 @@ h3 {
     overflow-y: auto;
 }
 
+.collapse_button {
+    background-color: lightgray;
+    border-radius: 5px; 
+    border-color:#646464;
+    cursor: move;
+}
+
 .items {
     padding-left: 10px;
     padding-top: 10px;

--- a/ui/tmnt/templates/tmnt/asset_viewer.html
+++ b/ui/tmnt/templates/tmnt/asset_viewer.html
@@ -226,7 +226,8 @@
         <!-- svg is generated into here -->
         <svg id="dfd_svg"></svg>
         <!-- bottom bar is generated into here -->
-        <div class="dfd_detailsbar" id="bottom_bar" onclick="collapse_bottom_bar()">
+        <button type="button" class="collapse_button" id="collapse_button" onclick="collapse_bottom_bar()" style="cursor: s-resize">&#8595</button>
+        <div class="dfd_detailsbar" id="bottom_bar">
             <h2 style="color: gray">No asset selected...</h2>
         </div>
     </div>
@@ -300,10 +301,14 @@
         // uncollapses if bottom bar is already collapsed
         if (dfd_svg_fraction == 1) {
             dfd_svg_fraction = 0.75;
+            document.getElementById("collapse_button").innerHTML = "&#8595";
+            document.getElementById("collapse_button").style.cursor = "s-resize";
         }
         // collapses if bottom bar is uncollapsed
         else {
             dfd_svg_fraction = 1;
+            document.getElementById("collapse_button").innerHTML = "&#8593";
+            document.getElementById("collapse_button").style.cursor = "n-resize";
         }
         svg = d3.select('#dfd_svg')
         .attr("width", area.width)


### PR DESCRIPTION
Clicking anywhere in the bottom bar area collapses the area. Clicking again uncollapses the bottom bar. However, when the bottom bar is collapsed, you can still scroll down to see the bottom bar. There is also no button to make it clear that the bottom bar is collapsible. Should I add one?