### PR TITLE
First Order Markov Chain

### DIFF
--- a/tmnpy/engines/models.py
+++ b/tmnpy/engines/models.py
@@ -1,0 +1,74 @@
+import numpy as np
+import random as rm
+import itertools
+import math
+
+class FirstOrderMarkovModel(object):
+
+    def __init__(self, states, initial_state, steps, weight="random", simulate=True, n_sim=1000):
+        self.states = states
+        self.initial_state = initial_state
+        self.steps = steps
+        self.state_size = len(states)
+
+        state_product = list(itertools.product(self.states, repeat=2))
+        state_product = [s[1] for s in state_product]
+        state_transition_matrix = [state_product[i*self.state_size:(i+1)*self.state_size] for i in range(self.state_size)]
+
+        self.transition_matrix = {}
+        for i in range(self.state_size):
+            if weight == "equal":
+                p = {state:1 / self.state_size for state in states}
+            elif weight=="random":
+                try:
+                    p = self.random_weight(self.state_size)
+                except ValueError:
+                    #if the probabilities sum to one before last val, we
+                    #error out and try again
+                    p = self.random_weight(self.state_size)
+            else:
+                e = "Specify either equal or random weights"
+                raise AttributeError(e)
+            self.transition_matrix[states[i]] = p
+
+        self.probs = self.initialize_probability()
+
+        if simulate:
+            self.simulation = []
+            for i in range(n_sim):
+                self.simulation.append(self.find_trajectory())
+
+    def random_weight(self, n):
+        p = {}
+        prob_sum = 0
+        for j in range(n):
+            if j == self.state_size - 1:
+                prob = 100 - prob_sum
+            else:
+                prob = rm.randrange(1, 100 - prob_sum)
+            prob_sum += prob
+            p[self.states[j]] = (prob/100)
+        return p
+
+    def transition_probability(self, t, probs):
+        probs[t] = {state:0 for state in self.states}
+        for prior_state, possible in self.transition_matrix.items():
+            for current_state, p in possible.items():
+                probs[t][current_state] += probs[t-1][prior_state] * p
+        return probs
+
+    def initialize_probability(self):
+        probs = {0:{state:0 for state in self.states}}
+        probs[0][self.initial_state] = 1
+        t = 1
+        while t <= self.steps:
+            probs = self.transition_probability(t, probs)
+            t += 1
+        return probs
+
+    def find_trajectory(self):
+        trajectory = []
+        for i in range(self.steps):
+            cpt = self.probs[i]
+            trajectory.append(np.random.choice(list(cpt.keys()), replace=True, p=list(cpt.values())))
+        return trajectory


### PR DESCRIPTION
Here's a first stab at the Markov Chain. To run 1k simulations with a random weighting you would do:

```python
#Specify the number of steps we want to make
steps = 3

initial_state = "Add Asset"

#The statespace - what actions the user might take
states = ["Add Asset","Change Asset","Add Threat","Add Control"]

model = FirstOrderMarkovModel(states, initial_state, steps)
```

In this example we could then see the results from the simulation with `model.simulation`, which returns a list of the trajectories for each sim (the series of events that would be recommended). This is a first-order Markov Model and so I think the next step would be to expand to M-order (where M is how many prior steps influence the weight). 

There's definitely a lot of room for improving this, such as we can't run additional sims after initially looking at the results and that I precompute all the probabilities before the sim (should be done on the fly). 