### PR TITLE
serializer additions

### DIFF
--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -1,0 +1,219 @@
+from tmnpy.dsl import Asset, Actor, Boundary, Data, DataFlow, ExternalEntity, Process, WorkFlow
+from tmnpy.dsl.asset import Machine
+from tmnpy.dsl.requirement import Property
+from tmnpy.dsl.data import Lifetime
+from tmnpy.util.serializer import TMNTSerializer
+
+import unittest
+
+
+class TestSerializerName(unittest.TestCase):
+    def setUp(self):
+        self.serializer = TMNTSerializer()
+        return super().setUp()
+
+    def test_asset_name(self):
+        a = Asset("test")
+        serealized = self.serializer.serialize(a, 0, {})
+
+        test_dict = {"name": "test"}
+        self.assertEqual(test_dict.items() <= serealized.items(), True)
+        self.assertEqual(serealized["name"], "test")
+        self.assertEqual(serealized["type"], "Asset")
+
+    def test_externalentity_name(self):
+        e = ExternalEntity("test")
+        serealized = self.serializer.serialize(e, 0, {})
+
+        test_dict = {"name": "test"}
+        self.assertEqual(test_dict.items() <= serealized.items(), True)
+        self.assertEqual(serealized["name"], "test")
+        self.assertEqual(serealized["type"], "ExternalEntity")
+
+    def test_process_name(self):
+        p = Process("test")
+        serealized = self.serializer.serialize(p, 0, {})
+
+        test_dict = {"name": "test"}
+        self.assertEqual(test_dict.items() <= serealized.items(), True)
+        self.assertEqual(serealized["name"], "test")
+        self.assertEqual(serealized["type"], "Process")
+
+    def test_actor_name(self):
+        a = Actor("test")
+        serealized = self.serializer.serialize(a, 0, {})
+        
+        test_dict = {"name": "test"}
+        self.assertEqual(test_dict.items() <= serealized.items(), True)
+        self.assertEqual(serealized["name"], "test")
+        self.assertEqual(serealized["type"], "Actor")
+
+    def test_boundary_name(self):
+        b = Boundary("test")
+        serealized = self.serializer.serialize(b, 0, {})
+        
+        test_dict = {"name": "test"}
+        self.assertEqual(test_dict.items() <= serealized.items(), True)
+        self.assertEqual(serealized["name"], "test")
+
+    def test_dataflow_name(self):
+        d = DataFlow("test", src = Asset("src"), dst = Asset("dst"))
+        serealized = self.serializer.serialize(d, 0, {})
+        
+        self.assertEqual(serealized["name"], "test")
+        self.assertEqual(serealized["src"]["name"], "src")
+        self.assertEqual(serealized["dst"]["name"], "dst")
+        self.assertEqual(serealized["type"], "DataFlow")
+
+    def test_workflow_name(self):
+        w = WorkFlow("test", src = Asset("src"), dst = Asset("dst"))
+        serealized = self.serializer.serialize(w, 0, {})
+        
+        self.assertEqual(serealized["name"], "test")
+        self.assertEqual(serealized["src"]["name"], "src")
+        self.assertEqual(serealized["dst"]["name"], "dst")
+        self.assertEqual(serealized["type"], "WorkFlow")
+
+    def tearDown(self) -> None:
+        return super().tearDown()
+
+
+class TestSerializerElements(unittest.TestCase):
+    def setUp(self):
+        self.serializer = TMNTSerializer()
+        return super().setUp()
+
+    def test_asset(self):
+        a = Asset("Life Support/Monitoring Equipment")
+        a.machine = "PHYSICAL"
+        a.open_port = [9999]
+        a.security_property.confidentiality = "HIGH"
+        a.security_property.integrity = "HIGH"
+        a.security_property.availability = "HIGH"
+        data_elem = Data("Patient Monitoring Data")
+        data_elem.is_pii = True
+        data_elem.is_phi = True
+        data_elem.format = "Digital"
+        data_elem.is_credentials = False
+        data_elem.desc = "Kept for the duration of the surgery"
+        data_elem.lifetime = "NONE"
+        a.data.append(data_elem)
+        serealized = self.serializer.serialize(a, 0, {})
+
+        self.assertEqual(serealized["name"], "Life Support/Monitoring Equipment")
+        self.assertEqual(serealized["type"], "Asset")
+        self.assertEqual(serealized["machine"], Machine.PHYSICAL)
+        self.assertEqual(serealized["open_port"], [9999])
+        self.assertEqual(serealized["security_property"]["confidentiality"], Property.HIGH)
+        self.assertEqual(serealized["security_property"]["integrity"], Property.HIGH)
+        self.assertEqual(serealized["security_property"]["availability"], Property.HIGH)
+        self.assertEqual(serealized["data"][0]["name"], "Patient Monitoring Data")
+        self.assertEqual(serealized["data"][0]["is_pii"], True)
+        self.assertEqual(serealized["data"][0]["is_phi"], True)
+        self.assertEqual(serealized["data"][0]["format"], "Digital")
+        self.assertEqual(serealized["data"][0]["is_credentials"], False)
+        self.assertEqual(serealized["data"][0]["desc"], "Kept for the duration of the surgery")
+        # self.assertEqual(serealized["data"][0]["lifetime"], Lifetime.NONE)
+
+    def test_actor(self):
+        a = Actor("Surgeon")
+        a.actor_type = "Individual"
+        a.internal = False
+        serealized = self.serializer.serialize(a, 0, {})
+
+        self.assertEqual(serealized["name"], "Surgeon")
+        self.assertEqual(serealized["type"], "Actor")
+        self.assertEqual(serealized["actor_type"], "Individual")
+        self.assertEqual(serealized["internal"], False)
+
+    def test_dataflow(self):
+        asset1 = Asset("Life Support/Monitoring Equipment")
+        asset2 = Asset("Surgeon Workstation")
+        d = DataFlow("Data Transfer from Life Support to Surgeon Workstation", src = asset1, dst = asset2)
+        d.port = "443"
+        d.protocol = "HTTPS"
+        d.authentication = "TLS"
+        d.multifactor_authentication = False
+        serealized = self.serializer.serialize(d, 0, {})
+
+        self.assertEqual(serealized["name"], "Data Transfer from Life Support to Surgeon Workstation")
+        self.assertEqual(serealized["type"], "DataFlow")
+        self.assertEqual(serealized["src"]["name"], "Life Support/Monitoring Equipment")
+        self.assertEqual(serealized["dst"]["name"], "Surgeon Workstation")
+        self.assertEqual(serealized["port"], "443")
+        self.assertEqual(serealized["protocol"], "HTTPS")
+        self.assertEqual(serealized["authentication"], "TLS")
+        self.assertEqual(serealized["multifactor"], False)
+
+    def test_workflow(self):
+        asset1 = Asset("Surgeon Workstation")
+        asset2 = Asset("Surgical Robot")
+        asset3 = Asset("Hospital Network")
+        w = WorkFlow("Surgical Procedure Execution Flow", src = asset1, dst = asset2)
+        w.path = [asset3]
+        serealized = self.serializer.serialize(w, 0, {})
+
+        self.assertEqual(serealized["name"], "Surgical Procedure Execution Flow")
+        self.assertEqual(serealized["type"], "WorkFlow")
+        self.assertEqual(serealized["src"]["name"], "Surgeon Workstation")
+        self.assertEqual(serealized["dst"]["name"], "Surgical Robot")
+        self.assertEqual(serealized["path"][1]["name"], "Hospital Network")
+
+    def tearDown(self) -> None:
+        return super().tearDown()
+
+
+class TestSerializerElementLists(unittest.TestCase):
+    def setUp(self):
+        self.serializer = TMNTSerializer()
+        return super().setUp()
+
+    def test_asset_list(self):
+        a1 = Asset("asset1")
+        a2 = Asset("asset2")
+        a3 = Asset("asset3")
+        serealized = self.serializer.serialize_list([a1, a2, a3], {})
+
+        self.assertEqual("assets" in serealized, True)
+        self.assertEqual(serealized["assets"][0]["name"], "asset1")
+        self.assertEqual(serealized["assets"][1]["name"], "asset2")
+        self.assertEqual(serealized["assets"][2]["name"], "asset3")
+
+    def test_boundary_list(self):
+        b1 = Boundary("boundary1")
+        b2 = Boundary("boundary2")
+        b3 = Boundary("boundary3")
+        serealized = self.serializer.serialize_list([b1, b2, b3], {})
+
+        self.assertEqual("boundaries" in serealized, True)
+        self.assertEqual(serealized["boundaries"][0]["name"], "boundary1")
+        self.assertEqual(serealized["boundaries"][1]["name"], "boundary2")
+        self.assertEqual(serealized["boundaries"][2]["name"], "boundary3")
+
+    def test_flow_list(self):
+        f1 = DataFlow("flow1", src = Asset("src1"), dst = Asset("dst1"))
+        f2 = WorkFlow("flow2", src = Asset("src2"), dst = Asset("dst2"))
+        f3 = DataFlow("flow3", src = Asset("src3"), dst = Asset("dst3"))
+        serealized = self.serializer.serialize_list([f1, f2, f3], {})
+
+        self.assertEqual("flows" in serealized, True)
+        self.assertEqual(serealized["flows"][0]["name"], "flow1")
+        self.assertEqual(serealized["flows"][0]["src"]["name"], "src1")
+        self.assertEqual(serealized["flows"][0]["dst"]["name"], "dst1")
+        self.assertEqual(serealized["flows"][1]["name"], "flow2")
+        self.assertEqual(serealized["flows"][1]["src"]["name"], "src2")
+        self.assertEqual(serealized["flows"][1]["dst"]["name"], "dst2")
+        self.assertEqual(serealized["flows"][2]["name"], "flow3")
+        self.assertEqual(serealized["flows"][2]["src"]["name"], "src3")
+        self.assertEqual(serealized["flows"][2]["dst"]["name"], "dst3")
+
+    def tearDown(self) -> None:
+        return super().tearDown()
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+
+

--- a/tests/test_tmntparser.py
+++ b/tests/test_tmntparser.py
@@ -26,9 +26,11 @@ class TestTMNTParser(unittest.TestCase):
 
         name = actor.name
         actor_type = actor.actor_type
+        physical_access = actor.physical_access
 
         self.assertEqual(name, "Surgeon")
         self.assertEqual(actor_type, "Individual")
+        self.assertEqual(physical_access, True)
 
     def test_parse_asset(self):
         asset_data = [
@@ -119,6 +121,7 @@ class TestTMNTParser(unittest.TestCase):
 
 
 class TestTMNTParser1(unittest.TestCase):
+
     def setUp(self):
         self.parser = TMNTParser(
             tm_name = "threatmodel_test", 
@@ -158,6 +161,7 @@ class TestTMNTParser1(unittest.TestCase):
         self.assertEqual(ds_type, DATASTORE_TYPE.UNKNOWN)
 
     def test_parse_boundary(self):
+
         boundary_data = [
             b for b in self.tm.boundaries if b.name == "boundary example"
         ]
@@ -167,193 +171,18 @@ class TestTMNTParser1(unittest.TestCase):
 
         name = boundary.name
         elements = boundary.elements
-        actors = boundary.actors
+        physical_access = boundary.physical_access
 
         self.assertEqual(name, "boundary example")
         self.assertEqual(elements[0].name, "asset example")
         self.assertEqual(elements[1].name, "process example")
         self.assertEqual(elements[2].name, "datastore example")
-        self.assertEqual(len(actors), 1)
-        self.assertEqual(actors[0][0].name, "actor example")
-        self.assertEqual(actors[0][1], True)
+        self.assertEqual(elements[3].name, "actor example")
+        self.assertIsInstance(elements[3], Actor)
+        self.assertEqual(len(physical_access), 1)
+        self.assertEqual(physical_access[0].name, "actor example")
+
  
-    def tearDown(self) -> None:
-        return super().tearDown()
-
-
-class TestMockDeviceDiagram(unittest.TestCase):
-    def setUp(self):
-        self.parser = TMNTParser(
-            tm_name = "mock_device_diagram_test", 
-            yaml = "test_mock_device_diagram.yaml",
-        )
-        self.tm = self.parser.tm
-        return super().setUp()
-
-    def test_parse_asset(self):
-        asset_data = [
-            a
-            for a in self.tm.enumerate_assets(Asset)
-            if a.name == "Hospital Infrastructure"
-        ]
-        self.assertEqual(len(asset_data), 1)
-        asset = asset_data[0]
-        self.assertIsInstance(asset, Asset)
-
-        name = asset.name
-        machine = asset.machine
-        open_ports = asset.open_ports
-
-        self.assertEqual(name, "Hospital Infrastructure")
-        self.assertEqual(machine, Machine.PHYSICAL)
-        self.assertEqual(open_ports, [22])
-        self.assertEqual(open_ports[0], 22)
-
-    def test_parse_datastore(self):
-        datastore_data = [
-            d 
-            for d in self.tm.enumerate_assets(Datastore) 
-            if d.name == "EHR Datastore"
-        ]
-        self.assertEqual(len(datastore_data), 1)
-        datastore = datastore_data[0]
-        self.assertIsInstance(datastore, Datastore)
-
-        name = datastore.name
-        machine = datastore.machine
-        open_ports = datastore.open_ports
-        ds_type = datastore.ds_type
-        desc = datastore.desc
-        data = datastore.data[0]
-        data1 = datastore.data[4]
-
-        self.assertEqual(name, "EHR Datastore")
-        self.assertEqual(machine, Machine.VIRTUAL)
-        self.assertEqual(open_ports, [443])
-        self.assertEqual(open_ports[0], 443)
-        self.assertEqual(ds_type, DATASTORE_TYPE.OTHER)
-        self.assertEqual(desc, "include later")
-        self.assertEqual(data.name, "Patient Vitals")
-        self.assertEqual(data.is_pii, True)
-        self.assertEqual(data.is_phi, True)
-        self.assertEqual(data.format, "log")
-        self.assertEqual(data.is_credentials, False)
-        self.assertEqual(data.lifetime, Lifetime.LONG)
-        self.assertEqual(data1.name, "Password")
-        self.assertEqual(data1.is_pii, False)
-        self.assertEqual(data1.is_phi, False)
-        self.assertEqual(data1.format, "String")
-        self.assertEqual(data1.is_credentials, True)
-        self.assertEqual(data1.lifetime, Lifetime.LONG)    
-
-    def test_parse_process(self):
-        process_data = [
-            p
-            for p in self.tm.enumerate_assets(Process) 
-            if p.name == "Life Support/Monitoring Equipment"
-        ]
-        self.assertEqual(len(process_data), 1)
-        process = process_data[0]
-        self.assertIsInstance(process, Process)
-
-        name = process.name
-        machine = process.machine
-        open_ports = process.open_ports
-        data = process.data[0]
-        data1 = process.data[1]
-
-        self.assertEqual(name, "Life Support/Monitoring Equipment")
-        self.assertEqual(machine, Machine.PHYSICAL)
-        self.assertEqual(open_ports, [9999])
-        self.assertEqual(open_ports[0], 9999)
-        self.assertEqual(data.name, "Patient Vitals")
-        self.assertEqual(data.is_pii, True)
-        self.assertEqual(data.is_phi, True)
-        self.assertEqual(data.format, "log")
-        self.assertEqual(data.is_credentials, False)
-        self.assertEqual(data.lifetime, Lifetime.LONG)
-        self.assertEqual(data1.name, "Encryption Keys")
-        self.assertEqual(data1.is_pii, False)
-        self.assertEqual(data1.is_phi, False)
-        self.assertEqual(data1.format, "RSA")
-        self.assertEqual(data1.is_credentials, True)
-        self.assertEqual(data1.lifetime, Lifetime.MANUAL)    
-
-    def test_parse_actors(self):
-        self.assertEqual(len(self.tm.actors), 10)
-        actor_data = [a for a in self.tm.actors if a.name == "Observer"]
-        self.assertEqual(len(actor_data), 1)
-        actor = actor_data[0]
-        self.assertIsInstance(actor, Actor)
-
-        name = actor.name
-        actor_type = actor.actor_type
-        internal = actor.internal
-
-        self.assertEqual(name, "Observer")
-        self.assertEqual(actor_type, "Individual")
-        self.assertEqual(internal, False)
-
-        actor_data1 = [a for a in self.tm.actors if a.name == "Manufacturer Techs"]
-        self.assertEqual(len(actor_data1), 1)
-        actor1 = actor_data1[0]
-        self.assertIsInstance(actor1, Actor)
-
-        name1 = actor1.name
-        actor_type1 = actor1.actor_type
-        internal1 = actor1.internal
-
-        self.assertEqual(name1, "Manufacturer Techs")
-        self.assertEqual(actor_type1, "Consultants")
-        self.assertEqual(internal1, True)
-
-    def test_parse_boundary(self):
-        self.assertEqual(len(self.tm.boundaries), 7)
-        boundary_data = [
-            b for b in self.tm.boundaries if b.name == "Cloud (Datastore)"
-        ]
-        self.assertEqual(len(boundary_data), 1)
-        boundary = boundary_data[0]
-        self.assertIsInstance(boundary, Boundary)
-
-        name = boundary.name
-        elements = boundary.elements
-        actors = boundary.actors
-
-        self.assertEqual(name, "Cloud (Datastore)")
-        self.assertEqual(len(elements), 1)
-        self.assertEqual(elements[0].name, "EHR Datastore")
-        self.assertEqual(len(actors), 3)
-        self.assertEqual(actors[0][0].name, "Cloud Provider")
-        self.assertEqual(actors[0][1], True)
-        self.assertEqual(actors[1][0].name, "Hospital 1 IT")
-        self.assertEqual(actors[1][1], False)
-        self.assertEqual(actors[2][0].name, "Support Consultants")
-        self.assertEqual(actors[2][1], False)
-
-    def test_parse_workflow(self):
-        workflow_data = [
-            a
-            for a in self.tm.enumerate_flows(WorkFlow)
-            if a.name == "Surgeon - Surgical Robot (internal)"
-        ]
-        self.assertEqual(len(workflow_data), 1)
-        workflow = workflow_data[0]
-        self.assertIsInstance(workflow, WorkFlow)
-
-        name = workflow.name
-        src = workflow.src
-        dst = workflow.dst
-        path = workflow.path
-        self.assertEqual(len(path), 3)
-
-        self.assertEqual(name, "Surgeon - Surgical Robot (internal)")
-        self.assertEqual(src.name, "Surgeon Workstation (internal)")
-        self.assertEqual(dst.name, "Hospital Infrastructure")
-        self.assertEqual(path[0].name, "Surgeon Workstation (internal)")
-        self.assertEqual(path[1].name, "Surgical Robot")
-        self.assertEqual(path[2].name, "Hospital Infrastructure")
-
     def tearDown(self) -> None:
         return super().tearDown()
 

--- a/tmnpy/dsl/asset.py
+++ b/tmnpy/dsl/asset.py
@@ -155,7 +155,6 @@ class Datastore(Asset):
     def __init__(
         self,
         name,
-        # machine: Machine | str = Machine.NA,
         ds_type: DATASTORE_TYPE | str = DATASTORE_TYPE.UNKNOWN,
         **kwargs,
     ):

--- a/tmnpy/dsl/flow.py
+++ b/tmnpy/dsl/flow.py
@@ -20,7 +20,6 @@ class Flow(Component):
         **kwargs,
     ):
         self.__path = []
-
         self.src = src
         self.dst = dst
         super().__init__(name, **kwargs)

--- a/tmnpy/util/exporter.py
+++ b/tmnpy/util/exporter.py
@@ -1,0 +1,199 @@
+
+
+# load threat model
+# class Parser(object):
+#     def load_yaml(self, file_path):
+#         with open(file_path, "r") as file:
+#             data = yaml.safe_load(file)
+#         return data
+
+
+class Exporter(object):
+    def __init__(self, tm_name: str):
+        self.tm = TM(tm_name)
+
+        # if "actors" in self.yaml.keys():
+        #     for actor in self.yaml["actors"]:
+        #         elem_type, kwargs = self.parse_element(actor)
+        #         self.tm.actors.append(elem_type(**kwargs))
+        # if "assets" in self.yaml.keys():
+        #     for asset in self.yaml["assets"]:
+        #         elem_type, kwargs = self.parse_component(asset)
+        #         self.tm.components.append(elem_type(**kwargs))
+        # if "flows" in self.yaml.keys():
+        #     for flow in self.yaml["flows"]:
+        #         elem_type, kwargs = self.parse_component(flow)
+        #         self.tm.components.append(elem_type(**kwargs))
+        # if "boundaries" in self.yaml.keys():
+        #     for boundary in self.yaml["boundaries"]:
+        #         elem_type, kwargs = self.parse_boundary(boundary)
+        #         self.tm.boundaries.append(elem_type(**kwargs)) 
+
+
+
+
+    def convert_boundary(self, boundary):
+
+    def convert_component(self, component):
+
+    def convert_element(self, element):
+
+
+
+
+#iterate through everything 
+
+
+# return a yaml file
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+"""
+create a dictionary 
+
+
+
+when you read in yaml fil eit read into a dictionary 
+
+
+figure out a way to convert the objects into dictionaries 
+
+
+
+only of hte first high level keys  is assets -. list of assets
+
+query the threat model 
+get me all of the assets
+
+
+
+
+2 ways 
+- no threat model jus otbject 
+- 2 dict 
+
+
+
+assets should get name, type (class name), security property, machine, data 
+create a function in the assets class classed 2 dict and build the dictionary
+
+create an assets object and 
+
+
+
+convert the diction to tmnpy object 
+take those tmnpy object turn to dictionary 
+and then turn to yaml 
+
+
+
+write the reverse opertation from parser 
+
+
+
+
+
+
+2 ways:
+- wtire 2 dict funtion (NO)
+- or serialer 
+        - list of objects and write reverse of parser
+
+
+
+
+
+python 
+from tmnpy.dsl import Asset, DataFlow
+test = Asset("test")
+dir(test)
+test.__dict__
+import yaml
+with open("test.yanml"m "w') as f:
+        yaml.safe_dump(test.__dict__, f)
+obj_dict = test.__dict__
+obj_dict
+for k, v, in obj_dict.items():
+    if isinstance(v, object):
+        print("found!", k)
+obj_dict["_Component__security_roperty"]
+obj_dict["_Component__security_roperty"].__dict__
+#in the case of none, they are those we dont need ot bother with 
+if none ifnore and not put in 
+
+
+
+
+
+run parser in terminal 
+have threat model objects 
+use those to help write out how you would parse it 
+
+keep iterating down until you find a place where it doesnt have dict  -> basic priminitve
+can serialize in yaml 
+
+
+if this is an object of this type -> stop here
+
+
+
+go all the way down 
+pass that all back and have massive dictionary 
+if nothing return nothing
+
+
+write that into initial 
+return 
+
+
+recurse for each of the piece apply dict 
+for any that doesnt fail get dict error
+
+take the dict and key at the end to the top
+
+
+
+start with one asset/workflow/dataflow /different elemtns 
+
+then do list of assets
+
+
+write test cases before write code 
+
+- create new test file in test directory 
+test_serializer.py
+
+from tmnpy.dsl import Asset
+
+import unittest 
+
+class TestSerialiEs (unittest.testcase):
+    def setup 
+
+    def test asset)name)only *self
+        x = Asset("test)
+        serealized = seializer(x)
+        seld.assertDictEqual("name":"TEst:m "type":"Asset"), serealized["assets"]) #should output dictionary
+
+
+
+
+
+serializer.py
+
+
+"""

--- a/tmnpy/util/serializer.py
+++ b/tmnpy/util/serializer.py
@@ -1,0 +1,75 @@
+import re
+
+from enum import Enum
+from tmnpy.dsl.element import Element
+
+class TMNTSerializer(object):
+
+    def serialize(self, element, pos, result_dict):
+        obj_dict = element.__dict__
+
+        type_name = type(element).__name__
+        if (
+            (type_name == "Asset") or \
+            (type_name == "Actor") or \
+            (type_name == "Boundary") or \
+            (type_name == "DataFlow") or \
+            (type_name == "ExternalEntity") or \
+            (type_name == "Process") or \
+            (type_name == "WorkFlow")
+        ):
+            result_dict["type"] = type_name
+
+        keys = list(obj_dict.keys())
+        if pos >= len(keys) or pos < 0:
+            return result_dict
+        else:
+            if "__" in keys[pos]: 
+                index = re.search("__", keys[pos]).end()
+                key = keys[pos][index:]
+            else:
+                key = keys[pos]
+
+            new_obj = obj_dict[keys[pos]]
+            try:
+                new_obj.__dict__
+                if isinstance(new_obj, Enum):
+                    raise AttributeError
+            except AttributeError:
+                if (isinstance(new_obj, list)) and (len(new_obj) > 0):
+                    if isinstance(new_obj[0], Element):
+                        obj_lst = []
+                        for obj in new_obj:
+                            obj_lst.append(self.serialize(obj, 0, {}))
+                        result_dict[key] = obj_lst
+                    else:
+                        result_dict[key] = new_obj
+                elif (
+                    (new_obj != None) and \
+                    (new_obj != "N/A") and \
+                    (new_obj != []) and \
+                    (new_obj != set())
+                ):
+                    result_dict[key] = new_obj
+            else:
+                result_dict[key] = self.serialize(new_obj, 0, {})
+                
+            return self.serialize(element, pos+1, result_dict)
+
+
+    def serialize_list(self, lst, result_dict):
+        elem_lst = []
+        for elem in lst:
+            elem_lst.append(self.serialize(elem, 0, {}))
+        
+        type_name = type(lst[0]).__name__
+        if ((type_name == "DataFlow") or (type_name == "WorkFlow")):
+            result_dict["flows"] = elem_lst
+        elif (type_name == "Boundary"):
+            result_dict["boundaries"] = elem_lst
+        else:
+            name = type_name.lower() + "s"
+            result_dict[name] = elem_lst
+            
+        return result_dict
+    


### PR DESCRIPTION
I was able to complete the serialization for singular objects and lists and turn them into dictionaries. 

Things that are left to complete:
- AssertionError with Lifetime Enum
- Only returning the name for objects that are within a different object type (e.g. if "src" in Data/WorkFlow is an Asset object, only return the "name" or return both "name" and "physical_access" for actors list in Boundary)
- Making the dictionary into a YAML file